### PR TITLE
Use crypto.randomBytes() for key generation

### DIFF
--- a/lib/watershed.js
+++ b/lib/watershed.js
@@ -114,11 +114,7 @@ Watershed()
 Watershed.prototype.generateKey = function
 generateKey()
 {
-	var nonce = new Buffer(NONCE_LENGTH);
-	for (var i = 0; i < nonce.length; i++) {
-		nonce[i] = Math.floor(Math.random() * 256);
-	}
-	return (nonce.toString('base64'));
+	return crypto.randomBytes(NONCE_LENGTH).toString('base64');
 }
 
 /*


### PR DESCRIPTION
Definitely a nit but there is no reason to loop over `Math.random`.
